### PR TITLE
fix: sync chart clock to playing audio

### DIFF
--- a/Assets/Scripts/Managers/AudioManager.cs
+++ b/Assets/Scripts/Managers/AudioManager.cs
@@ -169,6 +169,8 @@ public class AudioManager : MonoBehaviour
     private void Update()
     {
         if (timeProvider.IsRecord) return;
+
+        SyncTimeProviderToTrack();
         
         UpdateAnswerSfx();
         
@@ -250,6 +252,14 @@ public class AudioManager : MonoBehaviour
             if (i != TOUCHHOLD) //manual control
                 noteSfxPlaybackRequests[i] = false;
         }
+    }
+
+    private void SyncTimeProviderToTrack()
+    {
+        if (TrackSample == null || !TrackSample.IsPlaying) return;
+
+        var offset = TRACK_ANSWER_PLAYBACK_OFFSET_SEC + GlobalAudioOffset;
+        timeProvider.SyncAudioTime((float)(TrackSample.CurrentSec + offset));
     }
 
     private void OnDestroy()

--- a/Assets/Scripts/Managers/DataLoader.cs
+++ b/Assets/Scripts/Managers/DataLoader.cs
@@ -41,6 +41,8 @@ public class DataLoader : MonoBehaviour
     Dictionary<int, int> noteIndex = new();
     Dictionary<SensorType, int> touchIndex = new();
     private bool streamingRunning;
+    private bool initialPreloadComplete;
+    private int streamingVersion;
     List<TouchDrop> touchMembers = new();
     
     public Text diffText;
@@ -224,16 +226,23 @@ public class DataLoader : MonoBehaviour
         objectCounter.ReportMeterBpmAsync(chart).Forget();
         
         noteManager.ResetIndex();
+        initialPreloadComplete = false;
         streamingRunning = true;
-        StreamingCreate(chart.NoteTimings.ToArray(), ignoreOffset).Forget();
-        StreamingSetActive().Forget();
+        var version = ++streamingVersion;
+        StreamingCreate(chart.NoteTimings.ToArray(), ignoreOffset, version).Forget();
+        StreamingSetActive(version, ignoreOffset).Forget();
+    }
+
+    public async UniTask WaitForInitialPreloadAsync()
+    {
+        await UniTask.WaitUntil(() => initialPreloadComplete || !streamingRunning);
     }
     
-    private async UniTask StreamingCreate(SimaiTimingPoint[] timings, double ignoreOffset)
+    private async UniTask StreamingCreate(SimaiTimingPoint[] timings, double ignoreOffset, int version)
     {
         var i = 0;
 
-        while (i < timings.Length && timings[i].Timing < ignoreOffset)
+        while (i < timings.Length && timings[i].Timing < ignoreOffset && version == streamingVersion)
         {
             objectCounter
                 .CountIgnoreNoteCountAsync(timings[i].Notes)
@@ -243,10 +252,11 @@ public class DataLoader : MonoBehaviour
         }
         
         const double preloadTime = 20;
+        var isFirstPreload = true;
         
-        while (i < timings.Length && streamingRunning)
+        while (i < timings.Length && streamingRunning && version == streamingVersion)
         {
-            double now = Majdata<TimeProvider>.Instance!.NoteTime;
+            var now = GetStreamingTime(ignoreOffset);
             
             while (i < timings.Length)
             {
@@ -259,17 +269,26 @@ public class DataLoader : MonoBehaviour
                 
                 i++;
             }
+
+            if (isFirstPreload && version == streamingVersion)
+            {
+                initialPreloadComplete = true;
+                isFirstPreload = false;
+            }
             
             await UniTask.Yield();
         }
+
+        if (version == streamingVersion)
+            initialPreloadComplete = true;
     }
-    private async UniTask StreamingSetActive()
+    private async UniTask StreamingSetActive(int version, double fallbackTime)
     {
         const double preloadTime = 5;
 
-        while (streamingRunning)
+        while (streamingRunning && version == streamingVersion)
         {
-            double now = Majdata<TimeProvider>.Instance!.NoteTime;
+            var now = GetStreamingTime(fallbackTime);
             
             foreach (var note in noteManager.LoadedNotes)
             {
@@ -282,6 +301,12 @@ public class DataLoader : MonoBehaviour
 
             await UniTask.Yield();
         }
+    }
+
+    private double GetStreamingTime(double fallbackTime)
+    {
+        var timeProvider = Majdata<TimeProvider>.Instance!;
+        return timeProvider.IsStart ? timeProvider.NoteTime : fallbackTime;
     }
 
     private async UniTask LoadTiming(SimaiTimingPoint timing)
@@ -1165,6 +1190,8 @@ public class DataLoader : MonoBehaviour
     {
         loadedData = null;
         streamingRunning = false;
+        initialPreloadComplete = false;
+        streamingVersion++;
         for (var i = 1; i < 9; i++)
             noteIndex[i] = 0;
         for (var i = 0; i < 33; i++)

--- a/Assets/Scripts/Managers/DataLoader.cs
+++ b/Assets/Scripts/Managers/DataLoader.cs
@@ -50,6 +50,10 @@ public class DataLoader : MonoBehaviour
     public RawImage cardImage;
     public Color[] diffColors = new Color[7];
 
+    private const double StreamingCreatePreloadTime = 10;
+    private const double StreamingActivePreloadTime = 5;
+    private const double StreamingFrameBudgetMs = 4;
+
     private int slideLayer = -1;
     private int noteSortOrder = 0;
 
@@ -242,9 +246,8 @@ public class DataLoader : MonoBehaviour
             i++;
         }
         
-        const double preloadTime = 10;
-        i = await LoadStreamingWindow(timings, i, GetStreamingTime(ignoreOffset), preloadTime);
-        ContinueStreamingCreate(timings, i, ignoreOffset, preloadTime).Forget();
+        i = await LoadStreamingWindow(timings, i, ignoreOffset, StreamingCreatePreloadTime);
+        ContinueStreamingCreate(timings, i, ignoreOffset, StreamingCreatePreloadTime).Forget();
     }
 
     private async UniTask ContinueStreamingCreate(SimaiTimingPoint[] timings, int startIndex, double ignoreOffset, double preloadTime)
@@ -253,14 +256,16 @@ public class DataLoader : MonoBehaviour
 
         while (i < timings.Length && streamingRunning)
         {
-            i = await LoadStreamingWindow(timings, i, GetStreamingTime(ignoreOffset), preloadTime);
+            i = await LoadStreamingWindow(timings, i, ignoreOffset, preloadTime);
             await UniTask.Yield();
         }
     }
 
-    private async UniTask<int> LoadStreamingWindow(SimaiTimingPoint[] timings, int startIndex, double now, double preloadTime)
+    private async UniTask<int> LoadStreamingWindow(SimaiTimingPoint[] timings, int startIndex, double fallbackTime, double preloadTime)
     {
         var i = startIndex;
+        var now = GetStreamingTime(fallbackTime);
+        var frameStart = GetTimestamp();
 
         while (i < timings.Length && streamingRunning)
         {
@@ -271,6 +276,13 @@ public class DataLoader : MonoBehaviour
 
             await LoadTiming(timing);
             i++;
+
+            if (!IsFrameBudgetExceeded(frameStart))
+                continue;
+
+            await UniTask.Yield();
+            frameStart = GetTimestamp();
+            now = GetStreamingTime(fallbackTime);
         }
 
         return i;
@@ -278,23 +290,41 @@ public class DataLoader : MonoBehaviour
 
     private async UniTask StreamingSetActive(double fallbackTime)
     {
-        const double preloadTime = 5;
-
         while (streamingRunning)
         {
             var now = GetStreamingTime(fallbackTime);
+            var frameStart = GetTimestamp();
             
-            foreach (var note in noteManager.LoadedNotes)
+            for (var i = 0; i < noteManager.LoadedNotes.Count; i++)
             {
-                if (note.time - now > preloadTime)
+                var note = noteManager.LoadedNotes[i];
+                if (note.time - now > StreamingActivePreloadTime)
                     break;
 
                 if (!note.gameObject.activeSelf)
                     note.gameObject.SetActive(true);
+
+                if (!IsFrameBudgetExceeded(frameStart))
+                    continue;
+
+                await UniTask.Yield();
+                frameStart = GetTimestamp();
+                now = GetStreamingTime(fallbackTime);
             }
 
             await UniTask.Yield();
         }
+    }
+
+    private static long GetTimestamp()
+    {
+        return System.Diagnostics.Stopwatch.GetTimestamp();
+    }
+
+    private static bool IsFrameBudgetExceeded(long frameStart)
+    {
+        var elapsedMs = (GetTimestamp() - frameStart) * 1000d / System.Diagnostics.Stopwatch.Frequency;
+        return elapsedMs >= StreamingFrameBudgetMs;
     }
 
     private double GetStreamingTime(double fallbackTime)

--- a/Assets/Scripts/Managers/DataLoader.cs
+++ b/Assets/Scripts/Managers/DataLoader.cs
@@ -1,4 +1,4 @@
-﻿#region
+#region
 
 using System;
 using System.Collections.Generic;
@@ -209,7 +209,7 @@ public class DataLoader : MonoBehaviour
             touchIndex.Add((SensorType)i, 0); 
     }
     
-    public UniTask Load(SimaiChart chart, double ignoreOffset, string title, string artist, int diff, bool waitInitialPreload = false)
+    public async UniTask Load(SimaiChart chart, double ignoreOffset, string title, string artist, int diff)
     {
         titleText.text = title;
         artistText.text = artist;
@@ -226,15 +226,10 @@ public class DataLoader : MonoBehaviour
         streamingRunning = true;
         var timings = chart.NoteTimings.ToArray();
         StreamingSetActive(ignoreOffset).Forget();
-
-        if (waitInitialPreload)
-            return StreamingCreate(timings, ignoreOffset, true);
-
-        StreamingCreate(timings, ignoreOffset, false).Forget();
-        return UniTask.CompletedTask;
+        await StreamingCreate(timings, ignoreOffset);
     }
     
-    private async UniTask StreamingCreate(SimaiTimingPoint[] timings, double ignoreOffset, bool returnAfterInitialPreload)
+    private async UniTask StreamingCreate(SimaiTimingPoint[] timings, double ignoreOffset)
     {
         var i = 0;
 
@@ -247,16 +242,9 @@ public class DataLoader : MonoBehaviour
             i++;
         }
         
-        const double preloadTime = 20;
+        const double preloadTime = 10;
         i = await LoadStreamingWindow(timings, i, GetStreamingTime(ignoreOffset), preloadTime);
-
-        if (returnAfterInitialPreload)
-        {
-            ContinueStreamingCreate(timings, i, ignoreOffset, preloadTime).Forget();
-            return;
-        }
-
-        await ContinueStreamingCreate(timings, i, ignoreOffset, preloadTime);
+        ContinueStreamingCreate(timings, i, ignoreOffset, preloadTime).Forget();
     }
 
     private async UniTask ContinueStreamingCreate(SimaiTimingPoint[] timings, int startIndex, double ignoreOffset, double preloadTime)

--- a/Assets/Scripts/Managers/DataLoader.cs
+++ b/Assets/Scripts/Managers/DataLoader.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using Cysharp.Threading.Tasks;
 using MajSimai;
 using UnityEngine;
@@ -41,8 +40,6 @@ public class DataLoader : MonoBehaviour
     Dictionary<int, int> noteIndex = new();
     Dictionary<SensorType, int> touchIndex = new();
     private bool streamingRunning;
-    private bool initialPreloadComplete;
-    private int streamingVersion;
     List<TouchDrop> touchMembers = new();
     
     public Text diffText;
@@ -212,7 +209,7 @@ public class DataLoader : MonoBehaviour
             touchIndex.Add((SensorType)i, 0); 
     }
     
-    public void Load(SimaiChart chart, double ignoreOffset, string title, string artist, int diff)
+    public UniTask Load(SimaiChart chart, double ignoreOffset, string title, string artist, int diff, bool waitInitialPreload = false)
     {
         titleText.text = title;
         artistText.text = artist;
@@ -226,23 +223,22 @@ public class DataLoader : MonoBehaviour
         objectCounter.ReportMeterBpmAsync(chart).Forget();
         
         noteManager.ResetIndex();
-        initialPreloadComplete = false;
         streamingRunning = true;
-        var version = ++streamingVersion;
-        StreamingCreate(chart.NoteTimings.ToArray(), ignoreOffset, version).Forget();
-        StreamingSetActive(version, ignoreOffset).Forget();
-    }
+        var timings = chart.NoteTimings.ToArray();
+        StreamingSetActive(ignoreOffset).Forget();
 
-    public async UniTask WaitForInitialPreloadAsync()
-    {
-        await UniTask.WaitUntil(() => initialPreloadComplete || !streamingRunning);
+        if (waitInitialPreload)
+            return StreamingCreate(timings, ignoreOffset, true);
+
+        StreamingCreate(timings, ignoreOffset, false).Forget();
+        return UniTask.CompletedTask;
     }
     
-    private async UniTask StreamingCreate(SimaiTimingPoint[] timings, double ignoreOffset, int version)
+    private async UniTask StreamingCreate(SimaiTimingPoint[] timings, double ignoreOffset, bool returnAfterInitialPreload)
     {
         var i = 0;
 
-        while (i < timings.Length && timings[i].Timing < ignoreOffset && version == streamingVersion)
+        while (i < timings.Length && timings[i].Timing < ignoreOffset)
         {
             objectCounter
                 .CountIgnoreNoteCountAsync(timings[i].Notes)
@@ -252,41 +248,51 @@ public class DataLoader : MonoBehaviour
         }
         
         const double preloadTime = 20;
-        var isFirstPreload = true;
-        
-        while (i < timings.Length && streamingRunning && version == streamingVersion)
+        i = await LoadStreamingWindow(timings, i, GetStreamingTime(ignoreOffset), preloadTime);
+
+        if (returnAfterInitialPreload)
         {
-            var now = GetStreamingTime(ignoreOffset);
-            
-            while (i < timings.Length)
-            {
-                var timing = timings[i];
-
-                if (timing.Timing - now > preloadTime)
-                    break;
-                
-                await LoadTiming(timing);
-                
-                i++;
-            }
-
-            if (isFirstPreload && version == streamingVersion)
-            {
-                initialPreloadComplete = true;
-                isFirstPreload = false;
-            }
-            
-            await UniTask.Yield();
+            ContinueStreamingCreate(timings, i, ignoreOffset, preloadTime).Forget();
+            return;
         }
 
-        if (version == streamingVersion)
-            initialPreloadComplete = true;
+        await ContinueStreamingCreate(timings, i, ignoreOffset, preloadTime);
     }
-    private async UniTask StreamingSetActive(int version, double fallbackTime)
+
+    private async UniTask ContinueStreamingCreate(SimaiTimingPoint[] timings, int startIndex, double ignoreOffset, double preloadTime)
+    {
+        var i = startIndex;
+
+        while (i < timings.Length && streamingRunning)
+        {
+            i = await LoadStreamingWindow(timings, i, GetStreamingTime(ignoreOffset), preloadTime);
+            await UniTask.Yield();
+        }
+    }
+
+    private async UniTask<int> LoadStreamingWindow(SimaiTimingPoint[] timings, int startIndex, double now, double preloadTime)
+    {
+        var i = startIndex;
+
+        while (i < timings.Length && streamingRunning)
+        {
+            var timing = timings[i];
+
+            if (timing.Timing - now > preloadTime)
+                break;
+
+            await LoadTiming(timing);
+            i++;
+        }
+
+        return i;
+    }
+
+    private async UniTask StreamingSetActive(double fallbackTime)
     {
         const double preloadTime = 5;
 
-        while (streamingRunning && version == streamingVersion)
+        while (streamingRunning)
         {
             var now = GetStreamingTime(fallbackTime);
             
@@ -1190,8 +1196,6 @@ public class DataLoader : MonoBehaviour
     {
         loadedData = null;
         streamingRunning = false;
-        initialPreloadComplete = false;
-        streamingVersion++;
         for (var i = 1; i < 9; i++)
             noteIndex[i] = 0;
         for (var i = 0; i < 33; i++)

--- a/Assets/Scripts/Managers/PlayManager.cs
+++ b/Assets/Scripts/Managers/PlayManager.cs
@@ -161,14 +161,14 @@ public class PlayManager : MonoBehaviour
             switch (playmode)
             {
                 case PlaybackMode.Normal:
-                    loader.Load(_chart, startAt - offset, title, artist, difficulty).Forget();
+                    await loader.Load(_chart, startAt - offset, title, artist, difficulty);
                     
                     Majdata<AllPerfectManager>.Instance!.enabled = false;
                     timeProvider.SetStartTime(startAt, offset, speed, playmode);
                     audioManager.PlayTrack();
                     break;
                 case PlaybackMode.IncludeOp:
-                    loader.Load(_chart, startAt - offset, title, artist, difficulty).Forget();
+                    await loader.Load(_chart, startAt - offset, title, artist, difficulty);
 
                     bgManager.PlaySongDetail();
                     AudioManager.noteSfxPlaybackRequests[AudioManager.TRACK_START] = true; //track_start
@@ -184,7 +184,7 @@ public class PlayManager : MonoBehaviour
                         throw new InvalidPathException($"maidata path is required");
                     }
 
-                    await loader.Load(_chart, startAt - offset, title, artist, difficulty, true);
+                    await loader.Load(_chart, startAt - offset, title, artist, difficulty);
 
                     bgManager.PlaySongDetail();
                     

--- a/Assets/Scripts/Managers/PlayManager.cs
+++ b/Assets/Scripts/Managers/PlayManager.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 
 #region
 
@@ -169,7 +169,7 @@ public class PlayManager : MonoBehaviour
                     break;
                 case PlaybackMode.IncludeOp:
                     loader.Load(_chart, startAt - offset, title, artist, difficulty);
-                    
+
                     bgManager.PlaySongDetail();
                     AudioManager.noteSfxPlaybackRequests[AudioManager.TRACK_START] = true; //track_start
 
@@ -178,18 +178,20 @@ public class PlayManager : MonoBehaviour
                     audioManager.PlayTrack();
                     break;
                 case PlaybackMode.Record:
-                    loader.Load(_chart, startAt - offset, title, artist, difficulty);
-                    
-                    bgManager.PlaySongDetail();
-                    
                     canvasButtons.SetActive(false);
                     if (!Directory.Exists(maidataPath))
                     {
                         throw new InvalidPathException($"maidata path is required");
                     }
+
+                    loader.Load(_chart, startAt - offset, title, artist, difficulty);
+                    await loader.WaitForInitialPreloadAsync();
+
+                    bgManager.PlaySongDetail();
                     
                     Majdata<AllPerfectManager>.Instance!.enabled = true;
                     timeProvider.SetStartTime(startAt, offset, speed, playmode, _setting.OutputFps);
+                    timeProvider.Pause();
                     _state = ViewStatus.Playing;
                     screenRecorder.StartRecording(maidataPath, 
                         _setting.OutputFps, 

--- a/Assets/Scripts/Managers/PlayManager.cs
+++ b/Assets/Scripts/Managers/PlayManager.cs
@@ -161,14 +161,14 @@ public class PlayManager : MonoBehaviour
             switch (playmode)
             {
                 case PlaybackMode.Normal:
-                    loader.Load(_chart, startAt - offset, title, artist, difficulty);
+                    loader.Load(_chart, startAt - offset, title, artist, difficulty).Forget();
                     
                     Majdata<AllPerfectManager>.Instance!.enabled = false;
                     timeProvider.SetStartTime(startAt, offset, speed, playmode);
                     audioManager.PlayTrack();
                     break;
                 case PlaybackMode.IncludeOp:
-                    loader.Load(_chart, startAt - offset, title, artist, difficulty);
+                    loader.Load(_chart, startAt - offset, title, artist, difficulty).Forget();
 
                     bgManager.PlaySongDetail();
                     AudioManager.noteSfxPlaybackRequests[AudioManager.TRACK_START] = true; //track_start
@@ -184,8 +184,7 @@ public class PlayManager : MonoBehaviour
                         throw new InvalidPathException($"maidata path is required");
                     }
 
-                    loader.Load(_chart, startAt - offset, title, artist, difficulty);
-                    await loader.WaitForInitialPreloadAsync();
+                    await loader.Load(_chart, startAt - offset, title, artist, difficulty, true);
 
                     bgManager.PlaySongDetail();
                     

--- a/Assets/Scripts/Managers/ScreenRecorder.cs
+++ b/Assets/Scripts/Managers/ScreenRecorder.cs
@@ -125,6 +125,8 @@ public class ScreenRecorder : MonoBehaviour
                 var connectTask = pipeServer.WaitForConnectionAsync();
                 while (!connectTask.IsCompleted) await UniTask.Yield();
 
+                timeProvider.Resume(null);
+
                 using (var bw = new BinaryWriter(pipeServer))
                 {
                     while (IsRecording && !outProcess.HasExited)

--- a/Assets/Scripts/Managers/TimeProvider.cs
+++ b/Assets/Scripts/Managers/TimeProvider.cs
@@ -50,11 +50,19 @@ public class TimeProvider : MonoBehaviour
     {
         return NoteTime * 1000 / 16.6667f;
     }
-    //BUG: time goes faster
+
     public void SetStartTime(double _startAt, double _offset, float _speed, PlaybackMode mode, int fps = 60)
     {
+        IsStart = false;
+        IsRecord = false;
+        AudioTime = 0f;
+        NoteTime = 0f;
+        accumulated = 0f;
+        Time.timeScale = 1f;
+
         startAt = (float)_startAt;
         offset = (float)_offset;
+        speed = _speed;
 
         switch (mode)
         {
@@ -94,9 +102,21 @@ public class TimeProvider : MonoBehaviour
         if (!IsStart) return;
 
         var now = IsRecord ? Time.time : Time.realtimeSinceStartup;
-        accumulated += (now - startRealtime) * speed;
+        accumulated += IsRecord
+            ? now - startRealtime
+            : (now - startRealtime) * speed;
 
         IsStart = false;
+    }
+
+    public void SyncAudioTime(float syncedAudioTime)
+    {
+        if (!IsStart || IsRecord) return;
+
+        AudioTime = syncedAudioTime;
+        NoteTime = AudioTime - offset;
+        accumulated = AudioTime - startAt;
+        startRealtime = Time.realtimeSinceStartup;
     }
 
     public void Resume(float? _speed)

--- a/Assets/Scripts/Types/AudioSample.cs
+++ b/Assets/Scripts/Types/AudioSample.cs
@@ -90,6 +90,10 @@ public class AudioSample : IDisposable
         }
     }
 
+    public PlaybackState State => Bass.ChannelIsActive(Decode);
+
+    public bool IsPlaying => State == PlaybackState.Playing;
+
     public AudioSample(string file, AudioSampleMode mode)
     {
         Mode = mode;


### PR DESCRIPTION
### Motivation

- Streaming dataloader changes can expose small framerate hiccups that let the realtime-based `TimeProvider` drift away from the actual BASS audio clock, causing notes/SFX to desync over time.
- The intent is to keep `NoteTime` and SFX scheduling aligned with the actual playing track rather than only relying on `Time.realtimeSinceStartup`.

### Description

- Add `SyncAudioTime(float)` to `Assets/Scripts/Managers/TimeProvider.cs` to allow the audio position to overwrite `AudioTime`/`NoteTime` and re-anchor accumulated/startRealtime so the chart clock follows the track.
- Reset transient timing state at playback start in `TimeProvider.SetStartTime(...)` and fix pause accumulation so record vs normal modes do not double-apply `speed` during `Pause()`.
- In `Assets/Scripts/Managers/AudioManager.cs` call a new `SyncTimeProviderToTrack()` every `Update()` so when the BASS `TrackSample` is actually playing the `TimeProvider` will be synced to `TrackSample.CurrentSec` (taking `TRACK_ANSWER_PLAYBACK_OFFSET_SEC` and `GlobalAudioOffset` into account) before scheduling SFX.
- Expose playback helpers in `Assets/Scripts/Types/AudioSample.cs` (`State`/`IsPlaying`) using `Bass.ChannelIsActive(Decode)` so the sync only runs when the track is truly playing.

### Testing

- Ran `git diff --check` to validate the working tree and formatting, which succeeded.
- Performed local commits and basic repository checks (`git status`/`git log`) successfully; there were no automated Unity/CI tests run in this environment because the Unity editor/CLI is not available here. Please validate in-editor with playback/pause/resume/record scenarios to confirm SFX/notes remain locked to the audio clock.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07fb826bd88331ae1e9170837a9028)