### PR TITLE
Add native Apple Silicon macOS build

### DIFF
--- a/Assets/Editor/MacBuild.cs
+++ b/Assets/Editor/MacBuild.cs
@@ -1,0 +1,50 @@
+using System;
+using System.IO;
+using System.Linq;
+using MajdataViewX.Managers;
+using UnityEditor;
+using UnityEditor.Build.Profile;
+using UnityEditor.Build.Reporting;
+
+public static class MacBuild
+{
+    private const string OutputPath = "Builds/macOS/MajdataViewX.app";
+    private const string BuildProfilePath = "Assets/Settings/Build Profiles/macOS-arm64.asset";
+
+    public static void Verify()
+    {
+        if (!EditorBuildSettings.scenes.Any(scene => scene.enabled))
+            throw new InvalidOperationException("No enabled scene is configured for the macOS build.");
+
+        if (AssetDatabase.LoadAssetAtPath<BuildProfile>(BuildProfilePath) is null)
+            throw new InvalidOperationException("The Apple Silicon macOS build profile is missing.");
+
+        var bass = AssetImporter.GetAtPath("Assets/Plugins/macOS/libbass.dylib") as PluginImporter;
+        if (bass is null || !bass.GetCompatibleWithPlatform(BuildTarget.StandaloneOSX))
+            throw new InvalidOperationException("libbass.dylib is not enabled for macOS builds.");
+
+        var recorder = AssetImporter.GetAtPath("Assets/Plugins/x86_64/RenderingOut.dll") as PluginImporter;
+        if (recorder is null || recorder.GetCompatibleWithPlatform(BuildTarget.StandaloneOSX))
+            throw new InvalidOperationException("The Windows-only recorder must be excluded from macOS builds.");
+
+        if (ScreenRecorder.IsSupported)
+            throw new InvalidOperationException("Video recording must be disabled in the macOS player.");
+    }
+
+    [MenuItem("Build/macOS")]
+    public static void Build()
+    {
+        Verify();
+        Directory.CreateDirectory(Path.GetDirectoryName(OutputPath)!);
+
+        var report = BuildPipeline.BuildPlayer(new BuildPlayerWithProfileOptions
+        {
+            buildProfile = AssetDatabase.LoadAssetAtPath<BuildProfile>(BuildProfilePath),
+            locationPathName = OutputPath,
+            options = BuildOptions.None
+        });
+
+        if (report.summary.result != BuildResult.Succeeded)
+            throw new InvalidOperationException($"macOS build failed: {report.summary.result}");
+    }
+}

--- a/Assets/Editor/MacBuild.cs
+++ b/Assets/Editor/MacBuild.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using MajdataViewX.Managers;
 using UnityEditor;
 using UnityEditor.Build.Profile;
 using UnityEditor.Build.Reporting;
@@ -26,9 +25,6 @@ public static class MacBuild
         var recorder = AssetImporter.GetAtPath("Assets/Plugins/x86_64/RenderingOut.dll") as PluginImporter;
         if (recorder is null || recorder.GetCompatibleWithPlatform(BuildTarget.StandaloneOSX))
             throw new InvalidOperationException("The Windows-only recorder must be excluded from macOS builds.");
-
-        if (ScreenRecorder.IsSupported)
-            throw new InvalidOperationException("Video recording must be disabled in the macOS player.");
     }
 
     [MenuItem("Build/macOS")]

--- a/Assets/Editor/MacBuild.cs.meta
+++ b/Assets/Editor/MacBuild.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 660aefe35c1b43738bf491a2cc89df6b

--- a/Assets/Scripts/Base/MajEnv.cs
+++ b/Assets/Scripts/Base/MajEnv.cs
@@ -8,9 +8,9 @@ namespace MajdataViewX.Base
 #if UNITY_EDITOR
         // 编辑器下，指向项目根目录（Assets 的上一级）
         public static string MajBase = new DirectoryInfo(Application.dataPath).Parent!.FullName;
+#elif UNITY_STANDALONE_OSX
+        public static string MajBase => Path.Combine(Application.dataPath, "MacOS");
 #else
-        // 打包后，Application.dataPath 的上一级在 Windows 下是 exe 目录
-        // 但为了兼顾 Mac 等平台，用 AppContext 或者是 dataPath 的物理同级更安全
         public static string MajBase => System.AppDomain.CurrentDomain.BaseDirectory;
 #endif
 

--- a/Assets/Scripts/Base/MajEnv.cs
+++ b/Assets/Scripts/Base/MajEnv.cs
@@ -7,7 +7,7 @@ namespace MajdataViewX.Base
     {
 #if UNITY_EDITOR
         // 编辑器下，指向项目根目录（Assets 的上一级）
-        public static string MajBase = new DirectoryInfo(Application.dataPath).Parent!.FullName;
+        public static string MajBase => new DirectoryInfo(Application.dataPath).Parent!.FullName;
 #elif UNITY_STANDALONE_OSX
         public static string MajBase => Path.Combine(Application.dataPath, "MacOS");
 #else

--- a/Assets/Scripts/Managers/PlayManager.cs
+++ b/Assets/Scripts/Managers/PlayManager.cs
@@ -232,6 +232,12 @@ namespace MajdataViewX.Managers
             if (_state is not (ViewStatus.Loaded or ViewStatus.Paused))
                 return;
 
+            if (playmode is PlaybackMode.Record && !ScreenRecorder.IsSupported)
+            {
+                _wsServer.Error("Video recording is currently supported only on Windows.");
+                return;
+            }
+
             _state = ViewStatus.Busy;
             try
             {

--- a/Assets/Scripts/Managers/ScreenRecorder.cs
+++ b/Assets/Scripts/Managers/ScreenRecorder.cs
@@ -41,6 +41,17 @@ namespace MajdataViewX.Managers
 
 
         public bool IsRecording { get; private set; }
+        public static bool IsSupported
+        {
+            get
+            {
+#if UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN
+                return true;
+#else
+                return false;
+#endif
+            }
+        }
 
         private void Awake()
         {
@@ -51,6 +62,12 @@ namespace MajdataViewX.Managers
         public async UniTask StartRecording(string maidataPath,
             int fps, ExportQuality quality, [CanBeNull] Action onStart = null)
         {
+            if (!IsSupported)
+            {
+                _wsServer.Error("Video recording is currently supported only on Windows.");
+                return;
+            }
+
             QualitySettings.vSyncCount = 0;
             try
             {

--- a/Assets/Settings/Build Profiles/macOS-arm64.asset
+++ b/Assets/Settings/Build Profiles/macOS-arm64.asset
@@ -1,0 +1,49 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 15003, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: macOS-arm64
+  m_EditorClassIdentifier: UnityEditor.dll::UnityEditor.Build.Profile.BuildProfile
+  m_AssetVersion: 1
+  m_BuildTarget: 2
+  m_Subtarget: 2
+  m_PlatformId: 0d2129357eac403d8b359c2dcbf82502
+  m_PlatformBuildProfile:
+    rid: 6565264705881636864
+  m_OverrideGlobalSceneList: 0
+  m_Scenes: []
+  m_HasScriptingDefines: 0
+  m_ScriptingDefines: []
+  m_PlayerSettingsYaml:
+    m_Settings: []
+  references:
+    version: 2
+    RefIds:
+    - rid: 6565264705881636864
+      type: {class: OSXStandaloneBuildProfile, ns: UnityEditor.OSXStandalone, asm: UnityEditor.OSXStandalone.Extensions}
+      data:
+        m_Development: 0
+        m_ConnectProfiler: 0
+        m_BuildWithDeepProfilingSupport: 0
+        m_AllowDebugging: 0
+        m_WaitForManagedDebugger: 0
+        m_ManagedDebuggerFixedPort: 0
+        m_ExplicitNullChecks: 0
+        m_ExplicitDivideByZeroChecks: 0
+        m_ExplicitArrayBoundsChecks: 0
+        m_CompressionType: -1
+        m_InstallInBuildFolder: 0
+        m_InsightsSettingsContainer:
+          m_BuildProfileEngineDiagnosticsState: 2
+        m_AdaptivePerformanceEnabled: 0
+        m_MacOSXcodeBuildConfig: 1
+        m_Architecture: 1
+        m_CreateXcodeProject: 0

--- a/Assets/Settings/Build Profiles/macOS-arm64.asset.meta
+++ b/Assets/Settings/Build Profiles/macOS-arm64.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0a35e1cae0e1546d181b66329d57d438
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests.meta
+++ b/Assets/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1c72422a32584b2cbf43036afa599db9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/Runtime.meta
+++ b/Assets/Tests/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fddfbab3111149a4a14ee422793b360c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/Runtime/MajEnvPathTests.cs
+++ b/Assets/Tests/Runtime/MajEnvPathTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.IO;
 using System.Reflection;
 using NUnit.Framework;
@@ -18,35 +19,45 @@ public sealed class MajEnvPathTests
         Assert.That(Directory.Exists(majBase), Is.True);
     }
 
-    [Test]
+    [UnityTest]
     [UnityPlatform(RuntimePlatform.OSXEditor)]
-    public void UnsupportedRecordingLeavesPlayStateUntouched()
+    public IEnumerator UnsupportedRecordingLeavesPlayStateUntouched()
     {
         var playManagerType = Type.GetType("MajdataViewX.Managers.PlayManager, Assembly-CSharp", throwOnError: true)!;
         var wsServerType = Type.GetType("MajdataViewX.WsServer, Assembly-CSharp", throwOnError: true)!;
+        var majCtxType = Type.GetType("MajdataViewX.Base.MajCtx, Assembly-CSharp", throwOnError: true)!;
         var state = playManagerType.GetField("_state", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var wsServer = majCtxType.GetProperty("_wsServer", BindingFlags.Public | BindingFlags.Static)!;
         var loaded = Enum.Parse(state.FieldType, "Loaded");
         var previousState = state.GetValue(null);
-        var gameObject = new GameObject(nameof(UnsupportedRecordingLeavesPlayStateUntouched));
+        var previousWsServer = wsServer.GetValue(null);
+        var wsServerObject = new GameObject("Test WsServer");
+        var playManagerObject = new GameObject(nameof(UnsupportedRecordingLeavesPlayStateUntouched));
+        playManagerObject.SetActive(false);
 
         try
         {
-            gameObject.AddComponent(wsServerType);
-            var playManager = gameObject.AddComponent(playManagerType);
+            wsServerObject.AddComponent(wsServerType);
+            var playManager = playManagerObject.AddComponent(playManagerType);
             state.SetValue(null, loaded);
 
             var playAsync = playManagerType.GetMethod("PlayAsync")!;
             var record = Enum.Parse(playAsync.GetParameters()[0].ParameterType, "Record");
-            playAsync.Invoke(playManager, new[] { record, 0d, 1f, string.Empty });
+            var task = playAsync.Invoke(playManager, new[] { record, 0d, 1f, string.Empty })!;
+            var awaiter = task.GetType().GetMethod("GetAwaiter")!.Invoke(task, null)!;
+            var isCompleted = awaiter.GetType().GetProperty("IsCompleted")!;
+            while (!(bool)isCompleted.GetValue(awaiter)!)
+                yield return null;
+            awaiter.GetType().GetMethod("GetResult")!.Invoke(awaiter, null);
 
             Assert.That(state.GetValue(null), Is.EqualTo(loaded));
         }
         finally
         {
             state.SetValue(null, previousState);
-            LogAssert.ignoreFailingMessages = true;
-            UnityEngine.Object.DestroyImmediate(gameObject);
-            LogAssert.ignoreFailingMessages = false;
+            wsServer.SetValue(null, previousWsServer);
+            UnityEngine.Object.DestroyImmediate(playManagerObject);
+            UnityEngine.Object.DestroyImmediate(wsServerObject);
         }
     }
 }

--- a/Assets/Tests/Runtime/MajEnvPathTests.cs
+++ b/Assets/Tests/Runtime/MajEnvPathTests.cs
@@ -1,0 +1,18 @@
+using System;
+using System.IO;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+public sealed class MajEnvPathTests
+{
+    [Test]
+    [UnityPlatform(RuntimePlatform.OSXPlayer)]
+    public void MacPlayerUsesBundleExecutableDirectoryForReleaseAssets()
+    {
+        var majEnv = Type.GetType("MajdataViewX.Base.MajEnv, Assembly-CSharp", throwOnError: true)!;
+        var majBase = (string)majEnv.GetProperty("MajBase")!.GetValue(null)!;
+
+        Assert.That(majBase, Is.EqualTo(Path.Combine(Application.dataPath, "MacOS")));
+    }
+}

--- a/Assets/Tests/Runtime/MajEnvPathTests.cs
+++ b/Assets/Tests/Runtime/MajEnvPathTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Reflection;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
@@ -15,5 +16,37 @@ public sealed class MajEnvPathTests
 
         Assert.That(majBase, Is.EqualTo(Path.Combine(Application.dataPath, "MacOS")));
         Assert.That(Directory.Exists(majBase), Is.True);
+    }
+
+    [Test]
+    [UnityPlatform(RuntimePlatform.OSXEditor)]
+    public void UnsupportedRecordingLeavesPlayStateUntouched()
+    {
+        var playManagerType = Type.GetType("MajdataViewX.Managers.PlayManager, Assembly-CSharp", throwOnError: true)!;
+        var wsServerType = Type.GetType("MajdataViewX.WsServer, Assembly-CSharp", throwOnError: true)!;
+        var state = playManagerType.GetField("_state", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var loaded = Enum.Parse(state.FieldType, "Loaded");
+        var previousState = state.GetValue(null);
+        var gameObject = new GameObject(nameof(UnsupportedRecordingLeavesPlayStateUntouched));
+
+        try
+        {
+            gameObject.AddComponent(wsServerType);
+            var playManager = gameObject.AddComponent(playManagerType);
+            state.SetValue(null, loaded);
+
+            var playAsync = playManagerType.GetMethod("PlayAsync")!;
+            var record = Enum.Parse(playAsync.GetParameters()[0].ParameterType, "Record");
+            playAsync.Invoke(playManager, new[] { record, 0d, 1f, string.Empty });
+
+            Assert.That(state.GetValue(null), Is.EqualTo(loaded));
+        }
+        finally
+        {
+            state.SetValue(null, previousState);
+            LogAssert.ignoreFailingMessages = true;
+            UnityEngine.Object.DestroyImmediate(gameObject);
+            LogAssert.ignoreFailingMessages = false;
+        }
     }
 }

--- a/Assets/Tests/Runtime/MajEnvPathTests.cs
+++ b/Assets/Tests/Runtime/MajEnvPathTests.cs
@@ -14,5 +14,6 @@ public sealed class MajEnvPathTests
         var majBase = (string)majEnv.GetProperty("MajBase")!.GetValue(null)!;
 
         Assert.That(majBase, Is.EqualTo(Path.Combine(Application.dataPath, "MacOS")));
+        Assert.That(Directory.Exists(majBase), Is.True);
     }
 }

--- a/Assets/Tests/Runtime/MajEnvPathTests.cs.meta
+++ b/Assets/Tests/Runtime/MajEnvPathTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 837442dddb1f4ded93075bde512e0657
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Tests/Runtime/MajdataViewX.Tests.asmdef
+++ b/Assets/Tests/Runtime/MajdataViewX.Tests.asmdef
@@ -1,0 +1,6 @@
+{
+    "name": "MajdataViewX.Tests",
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ]
+}

--- a/Assets/Tests/Runtime/MajdataViewX.Tests.asmdef.meta
+++ b/Assets/Tests/Runtime/MajdataViewX.Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f6cf11aee8214675bbe86b3b797725b9
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ powershell -ExecutionPolicy Bypass -File .\ffmpeg-builder\build.ps1
 
 ## 文档 / Documentation
 
+- [macOS native build](docs/macos.md)
 - [中文 Wiki](https://github.com/LingFeng-bbben/MajdataView/wiki)
 - [English Guide On Charting](https://rentry.co/maiguide#making-the-chart)
 - [X新功能Wiki(不再维护，即将迁移)](https://github.com/re-poem/MajdataViewX/wiki)

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -1,0 +1,26 @@
+# macOS native build
+
+## Requirements
+
+- Unity `6000.3.19f1`
+- macOS Build Support (IL2CPP)
+- An activated Unity license
+
+## Build
+
+Run the checked-in build entry point from the repository root:
+
+```sh
+/Applications/Unity/Hub/Editor/6000.3.19f1/Unity.app/Contents/MacOS/Unity \
+  -batchmode -nographics -quit \
+  -projectPath "$PWD" \
+  -activeBuildProfile "Assets/Settings/Build Profiles/macOS-arm64.asset" \
+  -executeMethod MacBuild.Build \
+  -logFile -
+```
+
+The output is `Builds/macOS/MajdataViewX.app`. The build targets Apple Silicon, matching the `osx-arm64` MajdataEdit-Neo app.
+
+`SFX` and `Skin` are release assets rather than source files. The MajdataEdit-Neo macOS packager copies them into the final helper app.
+
+Video recording remains Windows-only. The macOS player returns an explicit error instead of loading `RenderingOut.dll`.

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -21,6 +21,6 @@ Run the checked-in build entry point from the repository root:
 
 The output is `Builds/macOS/MajdataViewX.app`. The build targets Apple Silicon, matching the `osx-arm64` MajdataEdit-Neo app.
 
-`SFX` and `Skin` are release assets rather than source files. The MajdataEdit-Neo macOS packager copies them into the final helper app.
+`SFX` and `Skin` are release assets rather than source files. The MajdataEdit-Neo macOS packager copies them into `MajdataViewX.app/Contents/MacOS`, where the macOS player resolves release assets at runtime.
 
 Video recording remains Windows-only. The macOS player returns an explicit error instead of loading `RenderingOut.dll`.


### PR DESCRIPTION
## Summary

- add a checked-in Unity 6 Apple Silicon build profile and batch build entry point
- verify the macOS BASS plugin and exclude the Windows-only recorder
- return an explicit error if recording is requested on non-Windows players
- document the native macOS build command

## Verification

- `MacBuild.Verify` passed with Unity 6000.3.19f1
- `MacBuild.Build` produced a successful IL2CPP player build
- main executable and GameAssembly are arm64
- app bundle passed strict code-signature verification
- packaged player launched on Apple M5 and listened on 127.0.0.1:8083