### PR TITLE
修复pv视频尺寸异常

### DIFF
--- a/Assets/Scripts/Managers/BgManager.cs
+++ b/Assets/Scripts/Managers/BgManager.cs
@@ -165,7 +165,11 @@ namespace MajdataViewX.Managers
                 }
                 else
                 {
-                    gameObject.transform.localScale = new Vector3(CIRCLED_SCALE_X, CIRCLED_SCALE_X * scale);
+                    var circleDiameter = circledBgMaterial.GetFloat("_Radius") * 2f;
+                    var spriteSize = spriteRender.sprite.bounds.size;
+                    var longestSide = Mathf.Max(spriteSize.x, spriteSize.y * scale);
+                    var fitScale = circleDiameter / longestSide;
+                    gameObject.transform.localScale = new Vector3(fitScale, fitScale * scale, fitScale);
                     spriteRender.material = circledBgMaterial;
                 }
             }


### PR DESCRIPTION
当前pv的显示尺寸过大，视频最外面一圈没有显示在圆形内，修复效果如图：

<img width="1038" height="511" alt="屏幕截图 2026-08-27 144155" src="https://github.com/user-attachments/assets/467e2e49-4ea3-4b8d-90ec-071b05e401f4" />
